### PR TITLE
Avoid shims for building

### DIFF
--- a/Formula/swi-prolog.rb
+++ b/Formula/swi-prolog.rb
@@ -3,7 +3,7 @@ class SwiProlog < Formula
   homepage "http://www.swi-prolog.org/"
   url "http://www.swi-prolog.org/download/stable/src/swipl-8.0.2.tar.gz"
   sha256 "abb81b55ac5f2c90997c0005b1f15b74ed046638b64e784840a139fe21d0a735"
-  revision 1
+  revision 2
   head "https://github.com/SWI-Prolog/swipl-devel.git"
 
   bottle do
@@ -29,7 +29,9 @@ class SwiProlog < Formula
       system "cmake", "..", *std_cmake_args,
                       "-DSWIPL_PACKAGES_JAVA=OFF",
                       "-DSWIPL_PACKAGES_X=OFF",
-                      "-DCMAKE_INSTALL_PREFIX=#{libexec}"
+                      "-DCMAKE_INSTALL_PREFIX=#{libexec}",
+                      "-DCMAKE_C_COMPILER=/usr/bin/clang",
+                      "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
       system "make", "install"
     end
 


### PR DESCRIPTION
Closes #38571
Since `swipl-ld` keeps in the binary the path information about the C and C++ compilers used at compile-time, avoid shims.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit` fails for reasons I don't understand about not being able to create some Makefiles necessary to install some gems…

I could only test with the most recent Xcode command-line-tools, not sure if it works for older versions.